### PR TITLE
Fix loggning error

### DIFF
--- a/custom_components/peaqhvac/service/hub/weather_prognosis.py
+++ b/custom_components/peaqhvac/service/hub/weather_prognosis.py
@@ -49,7 +49,8 @@ class WeatherPrognosis:
         if ret != self._weather_export_model:
             await self.observer.async_broadcast(ObserverTypes.PrognosisChanged)
             self._weather_export_model = ret
-            _LOGGER.debug("Weather-prognosis updated", ret)
+            # Fix the logging message to use proper formatting
+            _LOGGER.debug("Weather-prognosis updated: %s", ret)
 
     async def update_weather_prognosis(self):
         try:


### PR DESCRIPTION
Fix this issue:

```
--- Logging error ---
[36m2025-04-18 02:34:28.939 DEBUG (MainThread) [custom_components.peaqhvac.service.observer.iobserver_coordinator] received broadcast: ObserverTypes.PrognosisChanged - None[0m
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/logging/handlers.py", line 1493, in emit
    self.enqueue(self.prepare(record))
                 ~~~~~~~~~~~~^^^^^^^^
  File "/usr/local/lib/python3.13/logging/handlers.py", line 1475, in prepare
    msg = self.format(record)
  File "/usr/local/lib/python3.13/logging/__init__.py", line 998, in format
    return fmt.format(record)
           ~~~~~~~~~~^^^^^^^^
  File "/usr/local/lib/python3.13/logging/__init__.py", line 711, in format
    record.message = record.getMessage()
                     ~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/logging/__init__.py", line 400, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 227, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 213, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 154, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 712, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 683, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 2040, in _run_once
    handle._run()
  File "/usr/local/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/homeassistant/homeassistant/helpers/event.py", line 1658, in _interval_listener
    self.hass.async_run_hass_job(self._run_job, dt_util.utcnow(), background=True)
  File "/usr/src/homeassistant/homeassistant/core.py", line 943, in async_run_hass_job
    return self._async_add_hass_job(hassjob, *args, background=background)
  File "/usr/src/homeassistant/homeassistant/core.py", line 758, in _async_add_hass_job
    task = create_eager_task(
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 45, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/config/custom_components/peaqhvac/service/hub/weather_prognosis.py", line 52, in async_update_weather
    _LOGGER.debug("Weather-prognosis updated", ret)
  File "/usr/local/lib/python3.13/logging/__init__.py", line 1507, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/usr/local/lib/python3.13/logging/__init__.py", line 1664, in _log
    self.handle(record)
  File "/usr/local/lib/python3.13/logging/__init__.py", line 1680, in handle
    self.callHandlers(record)
  File "/usr/local/lib/python3.13/logging/__init__.py", line 1736, in callHandlers
    hdlr.handle(record)
  File "/usr/src/homeassistant/homeassistant/util/logging.py", line 113, in handle
    self.emit(record)
```